### PR TITLE
Moved lowest floor inside envelope

### DIFF
--- a/Floors/FloorsByLevels/README.md
+++ b/Floors/FloorsByLevels/README.md
@@ -4,9 +4,6 @@
 
 Creates Floors from LevelPerimeters supplied by another function.
 
-Source code:
-https://github.com/hypar-io/BuildingBlocks/tree/master/Floors/FloorsByLevels
-
 |Input Name|Type|Description|
 |---|---|---|
 |Floor Setback|Range|Setback of all floors from each level's perimeter.|

--- a/Floors/FloorsByLevels/src/FloorsByLevels.cs
+++ b/Floors/FloorsByLevels/src/FloorsByLevels.cs
@@ -45,6 +45,7 @@ namespace FloorsByLevels
                 floorArea += floor.Area();
             }
             floors = floors.OrderBy(f => f.Elevation).ToList();
+            floors.First().Transform.Move(new Vector3(0.0, 0.0, input.FloorThickness));
             var output = new FloorsByLevelsOutputs(floorArea, floors.Count());
             output.Model.AddElements(floors);
             return output;


### PR DESCRIPTION
Floors now thicken downward from a Level (as they should). The first level is at the bottom of the lowest envelope, leaving the resulting floor outside the envelope. This change moves the lowest floor into the envelope by elevating it by the floor's thickness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/31)
<!-- Reviewable:end -->
