### PR TITLE
Add autohiding to appropriate function dependencies.

### DIFF
--- a/Facade/FacadeByEnvelope/hypar.json
+++ b/Facade/FacadeByEnvelope/hypar.json
@@ -6,6 +6,7 @@
   "language": "C#",
   "model_dependencies": [
     {
+      "autohide": true,
       "name": "Envelope",
       "optional": false
     },

--- a/Floors/FloorsByLevels/hypar.json
+++ b/Floors/FloorsByLevels/hypar.json
@@ -6,6 +6,7 @@
   "language": "C#",
   "model_dependencies": [
     {
+      "autohide": true,
       "name": "Levels",
       "optional": false
     }

--- a/Floors/SubdivideSlab/hypar.json
+++ b/Floors/SubdivideSlab/hypar.json
@@ -6,6 +6,7 @@
   "language": "C#",
   "model_dependencies": [
     {
+      "autohide": true,
       "name": "Floors",
       "optional": false
     }


### PR DESCRIPTION
BACKGROUND
We have a "autohide" flag that lets us annotate that a function fully replaces one of its dependency's geometry, hiding the dependency in the 3d view when the dependent function is visible. We tested it by hard-coding a few specific dependencies.

DESCRIPTION:
This explicitly labels relevant dependencies in BuildingBlocks. Two of these are hard-coded in the UI already (Facade=>Envelope By Sketch and Floors=>Levels), so this lets us remove that hard coding and stops caring about which function produced the Envelope/Levels. It also adds Slab Subdivisions => Floor autohiding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/33)
<!-- Reviewable:end -->
