### PR TITLE
Add unit types to functions

### DIFF
--- a/Facade/FacadeByEnvelope/hypar.json
+++ b/Facade/FacadeByEnvelope/hypar.json
@@ -15,7 +15,54 @@
     }
   ],
   "model_output": "Facade",
-  "input_schema": {"type":"object","properties":{"Panel Width":{"type":"number","minimum":0.5,"maximum":4.0,"step":0.25,"default":1.0,"description":"The width of each facade panel.."},"Glass Left-Right Inset":{"type":"number","minimum":0.01,"maximum":1.0,"step":0.01,"description":"The inset of the glass panel from the left and right of the outer frame."},"Glass Top-Bottom Inset":{"type":"number","minimum":0.01,"maximum":1.0,"step":0.01,"description":"The inset of the glass panel from the top and bottom of the outer frame."},"Panel Color":{"$ref":"https://hypar.io/Schemas/Geometry/Color.json","default":{"Red":1.0,"Green":1.0,"Blue":1.0,"Alpha":1.0}},"Ground Floor Setback":{"type":"number","minimum":0,"maximum":2.0,"step":0.1,"default":1.0,"description":"The setback of the ground floor facade."}}},
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "Panel Width": {
+        "type": "number",
+        "minimum": 0.5,
+        "maximum": 4.0,
+        "step": 0.25,
+        "default": 1.0,
+        "description": "The width of each facade panel..",
+        "$hyparUnitType": "length"
+      },
+      "Glass Left-Right Inset": {
+        "type": "number",
+        "minimum": 0.01,
+        "maximum": 1.0,
+        "step": 0.01,
+        "description": "The inset of the glass panel from the left and right of the outer frame.",
+        "$hyparUnitType": "length"
+      },
+      "Glass Top-Bottom Inset": {
+        "type": "number",
+        "minimum": 0.01,
+        "maximum": 1.0,
+        "step": 0.01,
+        "description": "The inset of the glass panel from the top and bottom of the outer frame.",
+        "$hyparUnitType": "length"
+      },
+      "Panel Color": {
+        "$ref": "https://hypar.io/Schemas/Geometry/Color.json",
+        "default": {
+          "Red": 1.0,
+          "Green": 1.0,
+          "Blue": 1.0,
+          "Alpha": 1.0
+        }
+      },
+      "Ground Floor Setback": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 2.0,
+        "step": 0.1,
+        "default": 1.0,
+        "description": "The setback of the ground floor facade.",
+        "$hyparUnitType": "length"
+      }
+    }
+  },
   "outputs": [
     {
       "unit_type": "none",

--- a/Floors/FloorsByDXF/hypar.json
+++ b/Floors/FloorsByDXF/hypar.json
@@ -9,7 +9,7 @@
       "min": 1.0,
       "max": 10.0,
       "step": 1.0,
-      "unit_type": "none",
+      "unit_type": "length",
       "name": "Length",
       "description": "The length.",
       "type": "range"
@@ -18,7 +18,7 @@
       "min": 1.0,
       "max": 10.0,
       "step": 1.0,
-      "unit_type": "none",
+      "unit_type": "length",
       "name": "Width",
       "description": "The width.",
       "type": "range"

--- a/Floors/SubdivideSlab/hypar.json
+++ b/Floors/SubdivideSlab/hypar.json
@@ -17,7 +17,7 @@
       "min": 1.0,
       "max": 50.0,
       "step": 1.0,
-      "unit_type": "none",
+      "unit_type": "length",
       "name": "Length",
       "description": "The max length of each subdivision.",
       "type": "range"
@@ -26,7 +26,7 @@
       "min": 1.0,
       "max": 50.0,
       "step": 1.0,
-      "unit_type": "none",
+      "unit_type": "length",
       "name": "Width",
       "description": "The max width of each subdivision.",
       "type": "range"

--- a/Levels/LevelsByEnvelope/hypar.json
+++ b/Levels/LevelsByEnvelope/hypar.json
@@ -21,7 +21,8 @@
         "description": "Height of the top level.",
         "type": "number",
         "$hyparOrder": 2,
-        "minimum": 3
+        "minimum": 3,
+        "$hyparUnitType": "length"
       },
       "Ground Level Height": {
         "multipleOf": 0.1,
@@ -30,7 +31,8 @@
         "description": "Height of ground level.",
         "type": "number",
         "$hyparOrder": 0,
-        "minimum": 3
+        "minimum": 3,
+        "$hyparUnitType": "length"
       },
       "Standard Level Height": {
         "multipleOf": 0.1,
@@ -39,7 +41,8 @@
         "description": "Standard height of repeated levels.",
         "type": "number",
         "$hyparOrder": 1,
-        "minimum": 3
+        "minimum": 3,
+        "$hyparUnitType": "length"
       }
     }
   },

--- a/Roof/RoofBySketch/hypar.json
+++ b/Roof/RoofBySketch/hypar.json
@@ -18,9 +18,10 @@
         "type": "number",
         "minimum": 0.1,
         "maximum": 1.0,
-        "step": 0.01,
+        "multipleOf": 0.01,
         "default": 0.2,
-        "description": "Thickness of the Roof from its lowest point to its underside."
+        "description": "Thickness of the Roof from its lowest point to its underside.",
+        "$hyparUnitType": "length"
       }
     }
   },

--- a/Rooms/RoomsByLevels/hypar.json
+++ b/Rooms/RoomsByLevels/hypar.json
@@ -20,7 +20,7 @@
       "min": 1.7,
       "max": 4.0,
       "step": 0.1,
-      "unit_type": "none",
+      "unit_type": "length",
       "name": "Corridor Width",
       "description": "Width of the corridor.",
       "type": "range"
@@ -29,7 +29,7 @@
       "min": 20.0,
       "max": 200.0,
       "step": 1.0,
-      "unit_type": "none",
+      "unit_type": "length",
       "name": "Room Area",
       "description": "Desired area of each room.",
       "type": "range"


### PR DESCRIPTION
I went through and added unit designations to all functions where it was straightforward. I went ahead and deployed (testing on dev first, then prod — this change is a fairly straightforward and safe one.) Many already had units. I updated:
- Facade/Facade By Envelope
   - [X] Deployed to Dev
   - [X] Deployed to Prod
- Floors/SubdivideSlab
   - [X] Deployed to Dev
   - [X] Deployed to Prod
- Levels/LevelsByEnvelope
   - [X] Deployed to Dev
   - [X] Deployed to Prod


The following functions need some update, but it was more than just adding a line to hypar json, so I did not update them:
- Rooms/Program By CSV (there's already a "metric/imperial" toggle on the inputs, which should be removed, and the CSV input should be replaced with a list of objects (with built-in CSV up/download, which already handles unit conversion.))
- Rooms/RoomsByLevels (there's a build error — the `Elements.Room` constructor is missing an argument)
- Roof/Roof By Sketch (this has a reference to a local build of GeometryEx, so I didn't want to build for fear of breaking something)

Even for the functions I couldn't upload, I did modify their `hypar.json` where I could.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/42)
<!-- Reviewable:end -->
