### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @hypar-io/hypar-devs


### PR DESCRIPTION
This should automatically assign PRs to a random Hypar developer unless an individual member was specified.

See: https://stackoverflow.com/a/46346494

- [N/A] The function has been deployed to dev.
- [N/A] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/51)
<!-- Reviewable:end -->
