### PR TITLE
Floors By Levels optional Core dependency

### DIFF
--- a/Floors/FloorsByLevels/dependencies/LevelVolume.g.cs
+++ b/Floors/FloorsByLevels/dependencies/LevelVolume.g.cs
@@ -26,24 +26,14 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [Newtonsoft.Json.JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
-            var validator = Validator.Instance.GetFirstValidatorForType<LevelVolume>();
-            if(validator != null)
-            {
-                validator.PreConstruct(new object[]{ @profile, @height, @area, @transform, @material, @representation, @isElementDefinition, @id, @name});
-            }
-        
             this.Profile = @profile;
             this.Height = @height;
             this.Area = @area;
-            
-            if(validator != null)
-            {
-                validator.PostConstruct(this);
+            this.BuildingName = @buildingName;
             }
-        }
     
         /// <summary>The profile of the level Volume</summary>
         [Newtonsoft.Json.JsonProperty("Profile", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -56,6 +46,10 @@ namespace Elements
         /// <summary>The area of the level's profile.</summary>
         [Newtonsoft.Json.JsonProperty("Area", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Area { get; set; }
+    
+        /// <summary>The name of the building or mass this level belongs to (optional)</summary>
+        [Newtonsoft.Json.JsonProperty("Building Name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string BuildingName { get; set; }
     
     
     }

--- a/Floors/FloorsByLevels/hypar.json
+++ b/Floors/FloorsByLevels/hypar.json
@@ -9,6 +9,11 @@
       "autohide": true,
       "name": "Levels",
       "optional": false
+    },
+    {
+      "autohide": false,
+      "name": "Core",
+      "optional": true
     }
   ],
   "model_output": "Floors",

--- a/Floors/FloorsByLevels/src/FloorsByLevels.cs
+++ b/Floors/FloorsByLevels/src/FloorsByLevels.cs
@@ -16,6 +16,9 @@ namespace FloorsByLevels
         /// <returns>A FloorsByLevelsOutputs instance containing computed results and the model with any new elements.</returns>
         public static FloorsByLevelsOutputs Execute(Dictionary<string, Model> inputModels, FloorsByLevelsInputs input)
         {
+            inputModels.Keys.ToList().ForEach(key => Console.WriteLine(key));
+
+            // Extract LevelVolumes from Levels dependency
             var levels = new List<LevelPerimeter>();
             inputModels.TryGetValue("Levels", out var model);
             if (model == null ||
@@ -32,6 +35,17 @@ namespace FloorsByLevels
 
             levels.AddRange(model.AllElementsOfType<LevelPerimeter>());
 
+            // Extract shafts from Core dependency, if it exists
+            var shafts = new List<Polygon>();
+            inputModels.TryGetValue("Core", out var core);
+            if (core != null)
+            {
+                var shaftMasses = core.AllElementsOfType<Mass>();
+                var shaftPerimeters = shaftMasses.Where(mass => mass.Name == "void").Select(mass => mass.Profile.Perimeter.Project(new Plane(Vector3.Origin, Vector3.ZAxis)));
+
+                shafts.AddRange(shaftPerimeters);
+            }
+
             var floors = new List<Floor>();
             var floorArea = 0.0;
             if (levelVolumes.Count() > 0)
@@ -42,6 +56,11 @@ namespace FloorsByLevels
                     var elevation = level.Transform.Origin.Z;
                     if (flrOffsets.Count() > 0)
                     {
+                        if (shafts.Count() > 0)
+                        {
+                            flrOffsets = flrOffsets.Select(offset => new Profile(offset.Perimeter, shafts)).ToList();
+                        }
+
                         foreach (var fo in flrOffsets)
                         {
                             var floor = new Floor(fo, input.FloorThickness,
@@ -53,7 +72,9 @@ namespace FloorsByLevels
                     }
                     else
                     {
-                        var floor = new Floor(level.Profile, input.FloorThickness,
+                        var floorProfile = shafts.Count() > 0 ? new Profile(level.Profile.Perimeter, shafts) : level.Profile;
+
+                        var floor = new Floor(floorProfile, input.FloorThickness,
                                 new Transform(0.0, 0.0, elevation - input.FloorThickness),
                                 floorMaterial, null, false, Guid.NewGuid(), null);
                         floors.Add(floor);


### PR DESCRIPTION
Adds an optional dependency on Core to Floors By Levels that will create shaft openings, if present.

- [x] The function has been deployed to dev.
- [x] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).
