### PR TITLE
Long John Sliver

### DIFF
--- a/Floors/FloorsByLevels/README.md
+++ b/Floors/FloorsByLevels/README.md
@@ -4,16 +4,14 @@
 
 Creates floors from level perimeters supplied by another function.
 
-|Input Name|Type|Description|
-|---|---|---|
-|Floor Setback|number|Setback of all floors from each level's perimeter.|
-|Floor Thickness|number|Thickness of all floors.|
-
+| Input Name      | Type   | Description                                        |
+| --------------- | ------ | -------------------------------------------------- |
+| Floor Setback   | number | Setback of all floors from each level's perimeter. |
+| Floor Thickness | number | Thickness of all floors.                           |
 
 <br>
 
-|Output Name|Type|Description|
-|---|---|---|
-|Total Area|Number|Aggregate area of all floors.|
-|Floor Quantity|Number|Quantity of floors.|
-
+| Output Name    | Type   | Description                   |
+| -------------- | ------ | ----------------------------- |
+| Total Area     | Number | Aggregate area of all floors. |
+| Floor Quantity | Number | Quantity of floors.           |

--- a/Floors/FloorsByLevels/src/FloorsByLevels.cs
+++ b/Floors/FloorsByLevels/src/FloorsByLevels.cs
@@ -116,21 +116,29 @@ namespace FloorsByLevels
         {
             var initialProfile = new Profile(perimeter, openings);
 
-            var firstOffset = initialProfile.Offset(0.1);
+            try
+            {
+                var firstOffset = initialProfile.Offset(0.1);
 
-            if (firstOffset.FirstOrDefault() == null)
+                if (firstOffset.FirstOrDefault() == null)
+                {
+                    return initialProfile;
+                }
+
+                var secondOffset = firstOffset.OrderByDescending(profile => profile.Area()).First().Offset(-0.1);
+
+                if (secondOffset.FirstOrDefault() == null)
+                {
+                    return initialProfile;
+                }
+
+                return secondOffset.OrderByDescending(profile => profile.Area()).First();
+            }
+            catch
             {
                 return initialProfile;
             }
 
-            var secondOffset = firstOffset.OrderByDescending(profile => profile.Area()).First().Offset(-0.1);
-
-            if (secondOffset.FirstOrDefault() == null)
-            {
-                return initialProfile;
-            }
-
-            return secondOffset.OrderByDescending(profile => profile.Area()).First();
         }
     }
 }

--- a/Floors/FloorsByLevels/src/FloorsByLevels.cs
+++ b/Floors/FloorsByLevels/src/FloorsByLevels.cs
@@ -58,7 +58,7 @@ namespace FloorsByLevels
                     {
                         if (shafts.Count() > 0)
                         {
-                            flrOffsets = flrOffsets.Select(offset => new Profile(offset.Perimeter, shafts)).ToList();
+                            flrOffsets = flrOffsets.Select(offset => CreateFloorProfile(offset.Perimeter, shafts)).ToList();
                         }
 
                         foreach (var fo in flrOffsets)
@@ -72,7 +72,7 @@ namespace FloorsByLevels
                     }
                     else
                     {
-                        var floorProfile = shafts.Count() > 0 ? new Profile(level.Profile.Perimeter, shafts) : level.Profile;
+                        var floorProfile = shafts.Count() > 0 ? CreateFloorProfile(level.Profile.Perimeter, shafts) : level.Profile;
 
                         var floor = new Floor(floorProfile, input.FloorThickness,
                                 new Transform(0.0, 0.0, elevation - input.FloorThickness),
@@ -110,6 +110,27 @@ namespace FloorsByLevels
             var output = new FloorsByLevelsOutputs(floorArea, floors.Count());
             output.Model.AddElements(floors);
             return output;
+        }
+
+        private static Profile CreateFloorProfile(Polygon perimeter, List<Polygon> openings)
+        {
+            var initialProfile = new Profile(perimeter, openings);
+
+            var firstOffset = initialProfile.Offset(0.1);
+
+            if (firstOffset.FirstOrDefault() == null)
+            {
+                return initialProfile;
+            }
+
+            var secondOffset = firstOffset.OrderByDescending(profile => profile.Area()).First().Offset(-0.1);
+
+            if (secondOffset.FirstOrDefault() == null)
+            {
+                return initialProfile;
+            }
+
+            return secondOffset.OrderByDescending(profile => profile.Area()).First();
         }
     }
 }

--- a/Floors/FloorsByLevels/src/FloorsByLevelsOutputs.g.cs
+++ b/Floors/FloorsByLevels/src/FloorsByLevelsOutputs.g.cs
@@ -20,13 +20,13 @@ namespace FloorsByLevels
 		/// Aggregate area of all floors.
 		/// </summary>
 		[JsonProperty("Total Area")]
-		public double TotalArea {get; set;}
+		public double TotalArea {get;}
 
 		/// <summary>
 		/// Quantity of floors.
 		/// </summary>
 		[JsonProperty("Floor Quantity")]
-		public double FloorQuantity {get; set;}
+		public double FloorQuantity {get;}
 
 
 


### PR DESCRIPTION
If we're cutting holes out of Floors By Levels because of Core openings, perform an "inset-offset" to sanitize out any thin geometry (which is common in this case).

Existing code paths (i.e. no Core dependency) are unaffected.

- [x] The function has been deployed to dev.
- [x] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/63)
<!-- Reviewable:end -->
