### PR TITLE
Add U and V gridlines references to GridNode

### DIFF
--- a/Grids/Grid/dependencies/GridNode.g.cs
+++ b/Grids/Grid/dependencies/GridNode.g.cs
@@ -26,10 +26,12 @@ namespace Elements
     public partial class GridNode : Element
     {
         [Newtonsoft.Json.JsonConstructor]
-        public GridNode(Transform @location, System.Guid @id = default, string @name = null)
+        public GridNode(Transform @location, string @uGridline, string @vGridline, System.Guid @id = default, string @name = null)
             : base(id, name)
         {
             this.Location = @location;
+            this.UGridline = @uGridline;
+            this.VGridline = @vGridline;
             }
         
         // Empty constructor
@@ -41,6 +43,12 @@ namespace Elements
         /// <summary>The location of this grid node.</summary>
         [Newtonsoft.Json.JsonProperty("Location", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Transform Location { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("U Gridline", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string UGridline { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("V Gridline", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string VGridline { get; set; }
     
     
     }

--- a/Grids/Grid/src/Grid.cs
+++ b/Grids/Grid/src/Grid.cs
@@ -222,7 +222,11 @@ namespace Grid
                         if (uGridLine.Line.Intersects(vGridLine.Line, out var intersection, includeEnds: true))
                         {
                             var gridNodeTransform = new Transform(intersection);
-                            gridNodes.Add(new GridNode(gridNodeTransform, Guid.NewGuid(), $"{uGridLine.Name}{vGridLine.Name}"));
+                            gridNodes.Add(new GridNode(gridNodeTransform,
+                                                       uGridLine.Id.ToString(),
+                                                       vGridLine.Id.ToString(),
+                                                       Guid.NewGuid(),
+                                                       $"{uGridLine.Name}{vGridLine.Name}"));
 
                             if (input.ShowDebugGeometry)
                             {


### PR DESCRIPTION
Building Blocks contains many functions that are used in Hypar examples and in the Hypar tour. Please ensure that that following are true before granting this PR.

- [ ] The function has been deployed to dev.
- [ ] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/76)
<!-- Reviewable:end -->
