### PR TITLE
fix: Remove elevation offset

### DIFF
--- a/Grids/Grid/src/Grid.cs
+++ b/Grids/Grid/src/Grid.cs
@@ -324,13 +324,11 @@ namespace Grid
         {
             foreach (var gridline in gridlines)
             {
-                // Offset the grid visual from the XY plane to avoid z-fighting.
-                var elevation = new Vector3(0, 0, 0.01);
                 var line = gridline.Line;
                 var lineDir = (line.End - line.Start).Unitized();
                 var circleCenter = line.Start - (lineDir * (CircleRadius + lineHeadExtension));
                 var color = deduplicatedNamesGridLines.Contains(gridline) ? Colors.Red : Colors.Darkgray;
-                texts.Add((circleCenter + elevation, Vector3.ZAxis, lineDir, gridline.Name, color));
+                texts.Add((circleCenter, Vector3.ZAxis, lineDir, gridline.Name, color));
             }
         }
 


### PR DESCRIPTION
Building Blocks contains many functions that are used in Hypar examples and in the Hypar tour. Please ensure that that following are true before granting this PR.

- [x] The function has been deployed to dev.
- [x] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/78)
<!-- Reviewable:end -->
