### PR TITLE
Support Floors from Disjoint Level Volumes

### DIFF
--- a/Floors/FloorsByLevels/README.md
+++ b/Floors/FloorsByLevels/README.md
@@ -4,14 +4,16 @@
 
 Creates floors from level perimeters supplied by another function.
 
-| Input Name      | Type   | Description                                        |
-| --------------- | ------ | -------------------------------------------------- |
-| Floor Setback   | number | Setback of all floors from each level's perimeter. |
-| Floor Thickness | number | Thickness of all floors.                           |
+|Input Name|Type|Description|
+|---|---|---|
+|Floor Setback|number|Setback of all floors from each level's perimeter.|
+|Floor Thickness|number|Thickness of all floors.|
+
 
 <br>
 
-| Output Name    | Type   | Description                   |
-| -------------- | ------ | ----------------------------- |
-| Total Area     | Number | Aggregate area of all floors. |
-| Floor Quantity | Number | Quantity of floors.           |
+|Output Name|Type|Description|
+|---|---|---|
+|Total Area|Number|Aggregate area of all floors.|
+|Floor Quantity|Number|Quantity of floors.|
+


### PR DESCRIPTION
As we introduce more complex building massing with our new boolean capabilities, we need to update certain functions to handle new geometric cases. this PR adds support for generating floors from level volumes that include multiple disjoint sections, as in this workflow: https://dev.hypar.io/workflows/93923561-158f-49f4-9007-49f6961d292c. The PR for Levels By Envelope is forthcoming.

- [X] The function has been deployed to dev.
- [X] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/91)
<!-- Reviewable:end -->
