### PR TITLE
fix roof generation with last-ditch boolean

### DIFF
--- a/Roof/Roof/dependencies/Envelope.g.cs
+++ b/Roof/Roof/dependencies/Envelope.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class Envelope : GeometricElement
     {
         [JsonConstructor]
-        public Envelope(Profile @profile, double @elevation, double @height, Vector3 @direction, double @rotation, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public Envelope(Profile @profile, double @elevation, double @height, Vector3 @direction, double @rotation, IList<double> @floorToFloorHeights, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -35,6 +35,7 @@ namespace Elements
             this.Height = @height;
             this.Direction = @direction;
             this.Rotation = @rotation;
+            this.FloorToFloorHeights = @floorToFloorHeights;
             }
         
         // Empty constructor
@@ -62,6 +63,10 @@ namespace Elements
         /// <summary>The rotation of the envelope, in degrees.</summary>
         [JsonProperty("Rotation", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Rotation { get; set; }
+    
+        /// <summary>An optional list of floor-to-floor heights for this envelope. If provided, levels can be generated from these floor-to-floor heights.</summary>
+        [JsonProperty("Floor To Floor Heights", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<double> FloorToFloorHeights { get; set; }
     
     
     }

--- a/Roof/Roof/dependencies/RoofFunctionInputs.g.cs
+++ b/Roof/Roof/dependencies/RoofFunctionInputs.g.cs
@@ -62,7 +62,7 @@ namespace RoofFunction
         /// <summary>The Length.</summary>
         [Newtonsoft.Json.JsonProperty("Insulation Thickness", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Range(0.0D, 2D)]
-        public double InsulationThickness { get; set; } = 0.05D;
+        public double InsulationThickness { get; set; } = 0D;
     
         /// <summary>What color should be used to display the insulation</summary>
         [Newtonsoft.Json.JsonProperty("Insulation Color", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]

--- a/Roof/Roof/hypar.json
+++ b/Roof/Roof/hypar.json
@@ -63,54 +63,7 @@
                     "Blue": 0.5843137254901961,
                     "Green": 0.9764705882352941
                 },
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "x-namespace": "Elements.Geometry",
-                "description": "What color should be used to display the insulation",
-                "additionalProperties": false,
-                "$hyparOrder": 3,
-                "title": "Color",
-                "type": "object",
-                "required": [
-                    "Red",
-                    "Green",
-                    "Blue",
-                    "Alpha"
-                ],
-                "properties": {
-                    "Red": {
-                        "format": "float",
-                        "description": "The red component of the color between 0.0 and 1.0.",
-                        "maximum": 1,
-                        "type": "number",
-                        "$hyparOrder": 0,
-                        "minimum": 0
-                    },
-                    "Alpha": {
-                        "format": "float",
-                        "description": "The alpha component of the color between 0.0 and 1.0.",
-                        "maximum": 1,
-                        "type": "number",
-                        "$hyparOrder": 1,
-                        "minimum": 0
-                    },
-                    "Blue": {
-                        "format": "float",
-                        "description": "The blue component of the color between 0.0 and 1.0.",
-                        "maximum": 1,
-                        "type": "number",
-                        "$hyparOrder": 2,
-                        "minimum": 0
-                    },
-                    "Green": {
-                        "format": "float",
-                        "description": "The green component of the color between 0.0 and 1.0.",
-                        "maximum": 1,
-                        "type": "number",
-                        "$hyparOrder": 3,
-                        "minimum": 0
-                    }
-                },
-                "$id": "https://hypar.io/Schemas/Geometry/Color.json"
+                "$ref": "https://hypar.io/Schemas/Geometry/Color.json"
             },
             "Keep Roof Below Envelope": {
                 "description": "The height of the envelope is the top of the roof level",
@@ -137,5 +90,102 @@
     "repository_url": "https://github.com/hypar-io/function",
     "filters": {},
     "last_updated": "2022-06-16T05:20:20.226902",
-    "cli_version": "1.2.0-alpha.0"
+    "cli_version": "1.2.0-alpha.0",
+    "messages": {
+        "en": {
+            "name": "Roof",
+            "description": "Create a simple, schematic roof",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "Roof Color": {
+                        "description": "What color should be used to display the roof",
+                        "name": "Roof Color"
+                    },
+                    "Roof Thickness": {
+                        "name": "Roof Thickness"
+                    },
+                    "Insulation Thickness": {
+                        "name": "Insulation Thickness"
+                    },
+                    "Insulation Color": {
+                        "name": "Insulation Color"
+                    },
+                    "Keep Roof Below Envelope": {
+                        "description": "The height of the envelope is the top of the roof level",
+                        "name": "Keep Roof Below Envelope"
+                    }
+                }
+            },
+            "outputs": [
+                {
+                    "name": "Total Roof Area",
+                    "description": "The total roofing area."
+                }
+            ]
+        },
+        "jp": {
+            "description": "シンプルな概略屋根を作成する",
+            "input_schema": {
+                "properties": {
+                    "Insulation Color": {
+                        "name": "断熱材の色"
+                    },
+                    "Insulation Thickness": {
+                        "name": "断熱材の厚さ"
+                    },
+                    "Keep Roof Below Envelope": {
+                        "description": "エンベロープの高さはルーフ レベルの最上部です",
+                        "name": "ルーフをエンベロープの下に保つ"
+                    },
+                    "Roof Color": {
+                        "description": "屋根を表示するために使用する色",
+                        "name": "屋根の色"
+                    },
+                    "Roof Thickness": {
+                        "name": "屋根の厚さ"
+                    }
+                },
+                "type": ""
+            },
+            "name": "屋根",
+            "outputs": [
+                {
+                    "description": "屋根ふきの総面積。",
+                    "name": "総屋根面積"
+                }
+            ]
+        },
+        "de": {
+            "description": "Erstellen Sie ein einfaches, schematisches Dach",
+            "input_schema": {
+                "properties": {
+                    "Insulation Color": {
+                        "name": "Isolierungsfarbe"
+                    },
+                    "Insulation Thickness": {
+                        "name": "Isolierstärke"
+                    },
+                    "Keep Roof Below Envelope": {
+                        "description": "Die Höhe der Hülle ist die Oberkante der Dachebene",
+                        "name": "Halten Sie das Dach unter der Hülle"
+                    },
+                    "Roof Color": {
+                        "description": "In welcher Farbe soll das Dach dargestellt werden?",
+                        "name": "Dachfarbe"
+                    },
+                    "Roof Thickness": {
+                        "name": "Dachstärke"
+                    }
+                }
+            },
+            "name": "Dach",
+            "outputs": [
+                {
+                    "description": "Die gesamte Dachfläche.",
+                    "name": "Gesamte Dachfläche"
+                }
+            ]
+        }
+    }
 }

--- a/Roof/Roof/locales/de.json
+++ b/Roof/Roof/locales/de.json
@@ -1,0 +1,32 @@
+{
+    "description": "Erstellen Sie ein einfaches, schematisches Dach",
+    "input_schema": {
+        "properties": {
+            "Insulation Color": {
+                "name": "Isolierungsfarbe"
+            },
+            "Insulation Thickness": {
+                "name": "Isolierstärke"
+            },
+            "Keep Roof Below Envelope": {
+                "description": "Die Höhe der Hülle ist die Oberkante der Dachebene",
+                "name": "Halten Sie das Dach unter der Hülle"
+            },
+            "Roof Color": {
+                "description": "In welcher Farbe soll das Dach dargestellt werden?",
+                "name": "Dachfarbe"
+            },
+            "Roof Thickness": {
+                "name": "Dachstärke"
+            }
+        },
+        "type": "Objekt"
+    },
+    "name": "Dach",
+    "outputs": [
+        {
+            "description": "Die gesamte Dachfläche.",
+            "name": "Gesamte Dachfläche"
+        }
+    ]
+}

--- a/Roof/Roof/locales/en.json
+++ b/Roof/Roof/locales/en.json
@@ -1,0 +1,31 @@
+{
+    "name": "Roof",
+    "description": "Create a simple, schematic roof",
+    "input_schema": {
+        "properties": {
+            "Roof Color": {
+                "description": "What color should be used to display the roof",
+                "name": "Roof Color"
+            },
+            "Roof Thickness": {
+                "name": "Roof Thickness"
+            },
+            "Insulation Thickness": {
+                "name": "Insulation Thickness"
+            },
+            "Insulation Color": {
+                "name": "Insulation Color"
+            },
+            "Keep Roof Below Envelope": {
+                "description": "The height of the envelope is the top of the roof level",
+                "name": "Keep Roof Below Envelope"
+            }
+        }
+    },
+    "outputs": [
+        {
+            "name": "Total Roof Area",
+            "description": "The total roofing area."
+        }
+    ]
+}

--- a/Roof/Roof/locales/ja.json
+++ b/Roof/Roof/locales/ja.json
@@ -1,0 +1,32 @@
+{
+    "description": "シンプルな概略屋根を作成する",
+    "input_schema": {
+        "properties": {
+            "Insulation Color": {
+                "name": "断熱材の色"
+            },
+            "Insulation Thickness": {
+                "name": "断熱材の厚さ"
+            },
+            "Keep Roof Below Envelope": {
+                "description": "エンベロープの高さはルーフ レベルの最上部です",
+                "name": "ルーフをエンベロープの下に保つ"
+            },
+            "Roof Color": {
+                "description": "屋根を表示するために使用する色",
+                "name": "屋根の色"
+            },
+            "Roof Thickness": {
+                "name": "屋根の厚さ"
+            }
+        },
+        "type": ""
+    },
+    "name": "屋根",
+    "outputs": [
+        {
+            "description": "屋根ふきの総面積。",
+            "name": "総屋根面積"
+        }
+    ]
+}

--- a/Roof/Roof/src/Function.g.cs
+++ b/Roof/Roof/src/Function.g.cs
@@ -48,6 +48,7 @@ namespace RoofFunction
             {
                 try
                 {
+                    Console.WriteLine($"Assembly Name: {asm.FullName}");
                     Assembly.Load(asm);
                 }
                 catch (Exception e)


### PR DESCRIPTION
There was a case where the roof function was failing to compute due to a `Profile.Difference` failure (see https://hypar.io/workflows/247695fc-ec3c-4b0a-a907-2eb92567ef3f) 

I added my favorite "emergency escape" handling for this case — turn off validation, perform the difference, then offset it in and out a little bit. 

Building Blocks contains many functions that are used in Hypar examples and in the Hypar tour. Please ensure that that following are true before granting this PR.

- [X] The function has been deployed with `--stage` to prod.
- [NA] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).
- [X] Strings in `hypar.json` have been translated to supported languages in the `messages` field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/113)
<!-- Reviewable:end -->
