### PR TITLE
support roof on conceptual mass

### DIFF
--- a/Roof/Roof/README.md
+++ b/Roof/Roof/README.md
@@ -9,7 +9,7 @@ Create a simple, schematic roof
 |Roof Color|https://hypar.io/Schemas/Geometry/Color.json|What color should be used to display the roof|
 |Roof Thickness|number|The Length.|
 |Insulation Thickness|number|The Length.|
-|Insulation Color|object|What color should be used to display the insulation|
+|Insulation Color|https://hypar.io/Schemas/Geometry/Color.json||
 |Keep Roof Below Envelope|boolean|The height of the envelope is the top of the roof level|
 
 

--- a/Roof/Roof/dependencies/Envelope.g.cs
+++ b/Roof/Roof/dependencies/Envelope.g.cs
@@ -45,7 +45,7 @@ namespace Elements
         }
     
         /// <summary>The profile to extrude.</summary>
-        [JsonProperty("Profile", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Profile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Profile Profile { get; set; }
     
         /// <summary>The elevation of the envelope.</summary>

--- a/Roof/Roof/dependencies/LevelVolume.g.cs
+++ b/Roof/Roof/dependencies/LevelVolume.g.cs
@@ -43,7 +43,7 @@ namespace Elements
         }
     
         /// <summary>The profile of the level Volume</summary>
-        [JsonProperty("Profile", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Profile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Profile Profile { get; set; }
     
         /// <summary>The floor-to-floor height of this level</summary>

--- a/Roof/Roof/dependencies/Roof.g.cs
+++ b/Roof/Roof/dependencies/Roof.g.cs
@@ -41,7 +41,7 @@ namespace Elements
         }
     
         /// <summary>The roof's shape</summary>
-        [JsonProperty("Profile", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Profile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Profile Profile { get; set; }
     
         /// <summary>The roof's planar area</summary>

--- a/Roof/Roof/dependencies/RoofFunctionInputs.g.cs
+++ b/Roof/Roof/dependencies/RoofFunctionInputs.g.cs
@@ -64,7 +64,6 @@ namespace RoofFunction
         [System.ComponentModel.DataAnnotations.Range(0.0D, 2D)]
         public double InsulationThickness { get; set; } = 0D;
     
-        /// <summary>What color should be used to display the insulation</summary>
         [Newtonsoft.Json.JsonProperty("Insulation Color", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Color InsulationColor { get; set; }
     

--- a/Roof/Roof/hypar.json
+++ b/Roof/Roof/hypar.json
@@ -20,6 +20,11 @@
             "autohide": false,
             "name": "Masterplan",
             "optional": true
+        },
+        {
+            "autohide": false,
+            "name": "Conceptual Mass",
+            "optional": true
         }
     ],
     "model_output": "Roof",
@@ -85,7 +90,8 @@
         "https://prod-api.hypar.io/schemas/Roof",
         "https://prod-api.hypar.io/schemas/LevelVolume",
         "https://prod-api.hypar.io/schemas/Footprint",
-        "https://prod-api.hypar.io/schemas/Envelope"
+        "https://prod-api.hypar.io/schemas/Envelope",
+        "https://prod-api.hypar.io/schemas/ConceptualMass"
     ],
     "repository_url": "https://github.com/hypar-io/function",
     "filters": {},

--- a/Roof/Roof/src/RoofFunction.cs
+++ b/Roof/Roof/src/RoofFunction.cs
@@ -26,11 +26,17 @@ namespace RoofFunction
             var hasFootprints = inputModels.TryGetValue("Masterplan", out var masterplanModel);
             var hasEnvelopes = inputModels.TryGetValue("Envelope", out var envelopeModel);
             var hasLevels = inputModels.TryGetValue("Levels", out var levelsModel);
-            if (!hasEnvelopes && !hasFootprints && !hasLevels)
+            var hasConceptualMass = inputModels.TryGetValue("Conceptual Mass", out var massModel);
+            if (!hasEnvelopes && !hasFootprints && !hasLevels && !hasConceptualMass)
             {
-                output.Warnings.Add("There's nothing in the model from which to create a roof. Please add a footprint, envelope, or levels.");
+                output.Warnings.Add("There's nothing in the model from which to create a roof. Please add a conceptual mass, envelope, or levels.");
             }
-            if (hasFootprints)
+            if (hasConceptualMass)
+            {
+                var conceptualMass = massModel.AllElementsOfType<ConceptualMass>();
+                CreateRoofsFromElements(conceptualMass, input, output);
+            }
+            else if (hasFootprints)
             {
                 var footprints = masterplanModel.AllElementsOfType<Footprint>();
                 CreateRoofsFromElements(footprints, input, output);


### PR DESCRIPTION
Adds an optional dependency on "Conceptual Mass" to roof, so that it works w/ multifamily residential projects. 
- [X] The function has been deployed to dev.
- [NA] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).
- [X] Strings in `hypar.json` have been translated to supported languages in the `messages` field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/114)
<!-- Reviewable:end -->
