### PR TITLE
bump up minimum roof thickness

### DIFF
--- a/Roof/Roof/hypar.json
+++ b/Roof/Roof/hypar.json
@@ -49,7 +49,7 @@
                 "type": "number",
                 "$hyparUnitType": "length",
                 "$hyparOrder": 0,
-                "minimum": 0.1
+                "minimum": 0.001
             },
             "Insulation Thickness": {
                 "multipleOf": 0.01,


### PR DESCRIPTION
some roofs are less than 10cm thick, so we should allow that.

Building Blocks contains many functions that are used in Hypar examples and in the Hypar tour. Please ensure that that following are true before granting this PR.

- [x] The function has been deployed to dev.
~- [ ] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).~
~- [ ] Strings in `hypar.json` have been translated to supported languages in the `messages` field.~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/118)
<!-- Reviewable:end -->
