### PR TITLE
Configure codespaces so that hypar publishes correctly.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,19 @@
-# [Choice] .NET version: 6.0-bullseye, 3.1-bullseye, 6.0-focal, 3.1-focal
-ARG VARIANT=3.1
-FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/dotnet/.devcontainer/base.Dockerfile
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+# [Choice] .NET version: 6.0, 3.1, 6.0-bullseye, 3.1-bullseye, 6.0-focal, 3.1-focal
+ARG VARIANT="3.1-bullseye-slim"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 18, 16, 14
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# xdg-utils: required to open the login URL through xdg-open.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+     && apt-get -y install --no-install-recommends xdg-utils
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
-RUN dotnet tool install -g hypar.cli
-ENV PATH="${PATH}:${HOME}/vscode/.dotnet/tools"
+
+RUN dotnet tool install hypar.cli --tool-path /home/vscode/.dotnet/tools
+ENV PATH="${PATH}:/home/vscode/.dotnet/tools"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,3 +17,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 RUN dotnet tool install hypar.cli --tool-path /home/vscode/.dotnet/tools
 ENV PATH="${PATH}:/home/vscode/.dotnet/tools"
+
+# Reassign this to the user so that dotnet build can install more packages.
+RUN chown -R vscode /home/vscode/.dotnet

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/dotnet
 {
-    "build": {
-        "dockerfile": "./Dockerfile",
-        "context": "."
-    },
-    "features": {
-        "ghcr.io/devcontainers/features/common-utils:1": {
-            "installZsh": "true",
-            "username": "vscode",
-            "uid": "1000",
-            "gid": "1000",
-            "upgradePackages": "true"
-        },
-        "ghcr.io/devcontainers/features/node:1": {
-            "version": "none"
-        }
-    },
-    "overrideFeatureInstallOrder": [
-        "ghcr.io/devcontainers/features/common-utils"
-    ],
+	"name": "C# (.NET)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { 
+			// Update 'VARIANT' to pick a .NET Core version: 3.1, 6.0
+			// Append -bullseye or -focal to pin to an OS version.
+			"VARIANT": "3.1-bullseye",
+			// Options
+			"NODE_VERSION": "lts/*"
+		}
+	},
+
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.
-		"vscode": {
+		"vscode": {	
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-dotnettools.csharp"
@@ -31,6 +26,7 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [5000, 5001],
+
 	// [Optional] To reuse of your local HTTPS dev cert:
 	//
 	// 1. Export it locally using this command:
@@ -57,6 +53,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",
 
-	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {}
 }


### PR DESCRIPTION
DESCRIPTION
This rebuilds the codespaces config to:
- Use the bullseye dotnet containers to minimize container build time
- Install the hypar CLI into a user-visible directory
- Install xdb-utils to support Hypar sign-in through the CLI

TESTING
I created a new Codespace and ran `hypar new`:
- Login worked correctly. It redirected me to my own browser window, both when I tested in the browser-based codespace and in the VSCode-hosted codespace.
- The function built correctly, published correctly, and ran correctly on Hypar.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/119)
<!-- Reviewable:end -->
