### PR TITLE
Update Roof to support enclosure / conceptual mass

### DIFF
--- a/Roof/Roof/dependencies/LevelVolume.cs
+++ b/Roof/Roof/dependencies/LevelVolume.cs
@@ -1,0 +1,12 @@
+using Elements;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Elements.Geometry;
+namespace Elements
+{
+    public partial class LevelVolume
+    {
+        public Guid? Envelope { get; set; }
+    }
+}

--- a/Roof/Roof/dependencies/LevelVolume.g.cs
+++ b/Roof/Roof/dependencies/LevelVolume.g.cs
@@ -27,13 +27,15 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
             this.Height = @height;
             this.Area = @area;
             this.BuildingName = @buildingName;
+            this.Level = @level;
+            this.Mass = @mass;
             }
         
         // Empty constructor
@@ -57,6 +59,14 @@ namespace Elements
         /// <summary>The name of the building or mass this level belongs to (optional)</summary>
         [JsonProperty("Building Name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string BuildingName { get; set; }
+    
+        /// <summary>The Level this volume was created from.</summary>
+        [JsonProperty("Level", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Guid? Level { get; set; }
+    
+        /// <summary>The Conceptual Mass this volume was created from.</summary>
+        [JsonProperty("Mass", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Guid? Mass { get; set; }
     
     
     }

--- a/Roof/Roof/dependencies/RoofFunction.Dependencies.csproj
+++ b/Roof/Roof/dependencies/RoofFunction.Dependencies.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="0.9.9" />
-    <PackageReference Include="Hypar.Functions" Version="0.9.10" />
+    <PackageReference Include="Hypar.Elements" Version="1.2.0-alpha.24" />
+    <PackageReference Include="Hypar.Functions" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Roof/Roof/dependencies/RoofFunctionOutputs.g.cs
+++ b/Roof/Roof/dependencies/RoofFunctionOutputs.g.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 
 namespace RoofFunction
 {
-    public class RoofFunctionOutputs: ResultsBase
+    public class RoofFunctionOutputs: SystemResults
     {
 		/// <summary>
 		/// The total roofing area.

--- a/Roof/Roof/hypar.json
+++ b/Roof/Roof/hypar.json
@@ -25,6 +25,10 @@
             "autohide": false,
             "name": "Conceptual Mass",
             "optional": true
+        },
+        {
+            "name": "Enclosure",
+            "optional": true
         }
     ],
     "model_output": "Roof",

--- a/Roof/Roof/src/RoofFunction.cs
+++ b/Roof/Roof/src/RoofFunction.cs
@@ -118,7 +118,19 @@ namespace RoofFunction
                 else
                 {
                     var thisLevelprofiles = allLvs.Select(lv => lv.Profile);
-                    var difference = Profile.Difference(thisLevelprofiles, previousProfiles);
+                    List<Profile> difference = null;
+                    try
+                    {
+                        difference = Profile.Difference(thisLevelprofiles, previousProfiles);
+                    }
+                    catch
+                    {
+                        // try again if exceptions occur
+                        var offsetDistance = 0.01;
+                        var aOffset = Profile.Offset(thisLevelprofiles, -offsetDistance);
+                        var bOffset = Profile.Offset(previousProfiles, offsetDistance);
+                        difference = Profile.Offset(Profile.Difference(aOffset, bOffset), offsetDistance);
+                    }
                     if (difference != null && difference.Count > 0)
                     {
                         foreach (var profile in difference.Where(d => Math.Abs(d.Area()) > minRoofArea))

--- a/Roof/Roof/src/RoofFunction.cs
+++ b/Roof/Roof/src/RoofFunction.cs
@@ -135,12 +135,16 @@ namespace RoofFunction
                     {
                         foreach (var profile in difference.Where(d => Math.Abs(d.Area()) > minRoofArea))
                         {
-                            var roofs = CreateRoofAndInsulation(profile, input, allLvs.First().Transform.Concatenated(new Transform(0, 0, allLvs.First().Height)));
-                            if (allLvs.First().AdditionalProperties.TryGetValue("Envelope", out var envId))
+                            var firstLevel = allLvs.FirstOrDefault();
+                            if(firstLevel == null) {
+                                continue;
+                            }
+                            var roofs = CreateRoofAndInsulation(profile, input, firstLevel.Transform.Concatenated(new Transform(0, 0, firstLevel.Height)));
+                            if (firstLevel.AdditionalProperties.TryGetValue("Envelope", out var envId))
                             {
                                 roofs[0].AdditionalProperties.Add("Envelope", envId);
                             }
-                            if (allLvs.First().AdditionalProperties.TryGetValue("Footprint", out var fpId))
+                            if (firstLevel.AdditionalProperties.TryGetValue("Footprint", out var fpId))
                             {
                                 roofs[0].AdditionalProperties.Add("Footprint", fpId);
                             }

--- a/Roof/Roof/src/RoofFunction.cs
+++ b/Roof/Roof/src/RoofFunction.cs
@@ -51,9 +51,9 @@ namespace RoofFunction
                 }
                 var levelVolumesByBuilding = levelVolumes.GroupBy(lv =>
                 {
-                    var env = lv.Envelope;
+                    var env = lv.Mass ?? lv.Envelope;
                     var mass = massModel.Elements[env.Value] as ConceptualMass;
-                    return mass.Building ?? lv.Envelope;
+                    return mass.Building ?? lv.Mass ?? lv.Envelope;
                 });
                 foreach (var lvlVolumeGrp in levelVolumesByBuilding)
                 {

--- a/Roof/Roof/src/RoofFunction.csproj
+++ b/Roof/Roof/src/RoofFunction.csproj
@@ -4,11 +4,6 @@
     <ProjectReference Include="..\dependencies\RoofFunction.Dependencies.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="0.9.9" />
-    <PackageReference Include="Hypar.Functions" Version="0.9.10" />
-  </ItemGroup>
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>

--- a/Roof/Roof/test/RoofFunction.Tests.csproj
+++ b/Roof/Roof/test/RoofFunction.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Model" Version="0.9.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
As we move towards "Conceptual Mass" and "Enclosure" concepts, we want to make sure the roof function can produce its profile from an updated boundary, as generated in the enclosure function. This change looks for the updated level profiles injected by "Enclosure", and uses them as the roof profile if present. 
- [X] The function has been deployed to dev.
- [NA] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).
- [X] Strings in `hypar.json` have been translated to supported languages in the `messages` field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/buildingblocks/120)
<!-- Reviewable:end -->
