### PR TITLE
support conceptual mas in "grid"

### DIFF
--- a/Grids/Grid/README.md
+++ b/Grids/Grid/README.md
@@ -21,3 +21,4 @@ Create custom gridlines for your project using typical values, relative spacings
 <br>
 
 ## Additional Information
+

--- a/Grids/Grid/dependencies/Grid.Dependencies.csproj
+++ b/Grids/Grid/dependencies/Grid.Dependencies.csproj
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Hypar.Client" Version="0.9.7-alpha.5" />
     <PackageReference Include="Hypar.Elements" Version="1.4.0" />
-    <PackageReference Include="Hypar.Functions" Version="1.3.0" />
+    <PackageReference Include="Hypar.Functions" Version="1.4.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Grids/Grid/hypar.json
+++ b/Grids/Grid/hypar.json
@@ -21,6 +21,10 @@
       "optional": true
     },
     {
+      "name": "Conceptual Mass",
+      "optional": true
+    },
+    {
       "autohide": false,
       "name": "Floors",
       "optional": true

--- a/Grids/Grid/src/Grid.cs
+++ b/Grids/Grid/src/Grid.cs
@@ -51,10 +51,12 @@ namespace Grid
                 extentPolygons = ExtractPolygonsFromElements(roofs, (e) => e.Profile?.Perimeter?.TransformedPolygon(e.Transform));
             }
 
+            inputModels.TryGetValue("Conceptual Mass", out var conceptualMassModel);
             inputModels.TryGetValue("Levels", out var levelsModel);
-            if (levelsModel != null && extentPolygons.Count == 0)
+            var levelVolumesModel = conceptualMassModel ?? levelsModel;
+            if (levelVolumesModel != null && extentPolygons.Count == 0)
             {
-                var levelVolumes = levelsModel.AllElementsOfType<LevelVolume>();
+                var levelVolumes = levelVolumesModel.AllElementsOfType<LevelVolume>();
                 extentPolygons = ExtractPolygonsFromElements(levelVolumes, (e) => e.Profile?.Perimeter?.TransformedPolygon(e.Transform));
             }
 


### PR DESCRIPTION
`Grid` function didn't support getting its level volumes from the conceptual mass dependency. Currently published with this change in `test` mode. 
![image](https://user-images.githubusercontent.com/31935763/218318393-4c8b6011-62e7-4a00-8667-702d79fb21c0.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/BuildingBlocks/129)
<!-- Reviewable:end -->
