### PR TITLE
Update Elements to latest alpha of 2.0 for every function using PointAt or TransformAt

### DIFF
--- a/EmergencyEgress/dependencies/EmergencyEgress.Dependencies.csproj
+++ b/EmergencyEgress/dependencies/EmergencyEgress.Dependencies.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="1.6.1" />
+    <PackageReference Include="Hypar.Elements" Version="2.0.0-alpha.23" />
     <PackageReference Include="Hypar.Functions" Version="1.6.0" />
   </ItemGroup>
 

--- a/EmergencyEgress/src/EmergencyEgress.cs
+++ b/EmergencyEgress/src/EmergencyEgress.cs
@@ -376,7 +376,7 @@ namespace EmergencyEgress
                 return null;
             }
 
-            var midpoint = door?.Transform.Origin ?? roomEdge.PointAt(0.5);
+            var midpoint = door?.Transform.Origin ?? roomEdge.Mid();
 
             foreach (var line in centerlines)
             {

--- a/Facade/FacadeByEnvelope/dependencies/FacadeByEnvelope.Dependencies.csproj
+++ b/Facade/FacadeByEnvelope/dependencies/FacadeByEnvelope.Dependencies.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="1.4.0" />
-    <PackageReference Include="Hypar.Functions" Version="1.3.0" />
+    <PackageReference Include="Hypar.Elements" Version="2.0.0-alpha.23" />
+    <PackageReference Include="Hypar.Functions" Version="1.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Facade/FacadeByEnvelope/src/FacadeByEnvelope.cs
+++ b/Facade/FacadeByEnvelope/src/FacadeByEnvelope.cs
@@ -249,7 +249,7 @@ namespace FacadeByEnvelope
             // Console.WriteLine($"The line {l} units long will create {divs} panels of {d} width");
             var span = divs * d;
             var halfSpan = span / 2;
-            var mid = line.PointAt(0.5);
+            var mid = line.Mid();
             var dir = line.Direction();
             var start = mid - dir * halfSpan;
             var end = mid + dir * halfSpan;

--- a/Grids/Grid/src/Grid.cs
+++ b/Grids/Grid/src/Grid.cs
@@ -300,12 +300,12 @@ namespace Grid
                     transform, Grid2dElementMaterial, rep, false, Guid.NewGuid(), gridArea.Name);
                 grid2dElement.Extents = boundary;
                 grid2dElement.AdditionalProperties["UGrid"] = new Grid1dInput(
-                    new Polyline(origin, grid.U.Curve.PointAt(1)),
+                    new Polyline(origin, grid.U.Curve.End),
                     uPoints,
                     uOverride?.SubdivisionMode ?? Grid1dInputSubdivisionMode.Manual,
                     uOverride?.SubdivisionSettings);
                 grid2dElement.AdditionalProperties["VGrid"] = new Grid1dInput(
-                    new Polyline(origin, grid.V.Curve.PointAt(1)),
+                    new Polyline(origin, grid.V.Curve.End),
                     vPoints,
                     vOverride?.SubdivisionMode ?? Grid1dInputSubdivisionMode.Manual,
                     vOverride?.SubdivisionSettings);
@@ -376,16 +376,16 @@ namespace Grid
         private static string ConvertToANamingPattern(int idx)
         {
             // Let Q = 26 - number of uppercase characters, N - number of letters in string.
-            // There are Q^N strings of length N. The first string of length N+1 will have 
+            // There are Q^N strings of length N. The first string of length N+1 will have
             // idx = Q^1 + Q^2 + ... + Q^n, which is equal to Q * (Q^N - 1) / (Q - 1).
-            const int Q = 26; 
+            const int Q = 26;
             int N = (int)Math.Ceiling(Math.Log((Q - 1) * (idx + 1) + Q, Q) - 1);
             char[] chars = new char[N];
 
             // The goal is to represent idx in string S as a set of characters Ki, where 0 <= Ki < Q.
             // Such polynomial is unique for each idx.
-            // S = K0 + K1 * Q + K2 * Q^2 + ... + K_n-1_ * Q^(N - 1). 
-            // 
+            // S = K0 + K1 * Q + K2 * Q^2 + ... + K_n-1_ * Q^(N - 1).
+            //
             // Each letter Ki are calculated in reverse order as reminder of dividing S by Q.
             // Then the letter is removed by dividing and thus dropping the reminder.
             for (int i = N - 1; i >= 0; i--)
@@ -457,7 +457,7 @@ namespace Grid
                                                 GridlineNamesIdentityAxis axis,
                                                 double radius)
         {
-            var baseLine = new Line(opposingGrid1d.Curve.PointAt(0), opposingGrid1d.Curve.PointAt(1));
+            var baseLine = new Line(opposingGrid1d.Curve.Start, opposingGrid1d.Curve.End);
 
             var startExtend = origin - baseLine.Start;
             var endExtend = origin - baseLine.End;
@@ -584,7 +584,7 @@ namespace Grid
         private static U GetStandardizedRecords(U u, Grid1dInput uOverride)
         {
             var gridlines = new List<GridLines>();
-            var start = uOverride.Curve.PointAt(0);
+            var start = uOverride.Curve.Start;
             var splitPoints = uOverride.SplitPoints
                                 .Select(p => p.DistanceTo(start))
                                 .OrderBy(d => d)

--- a/Structure/StructureByEnvelope/dependencies/LevelPerimeter.g.cs
+++ b/Structure/StructureByEnvelope/dependencies/LevelPerimeter.g.cs
@@ -52,7 +52,7 @@ namespace Elements
         public double Elevation { get; set; }
     
         /// <summary>The perimeter of the level perimeter.</summary>
-        [JsonProperty("Perimeter", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Perimeter", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Polygon Perimeter { get; set; }
     
     

--- a/Structure/StructureByEnvelope/dependencies/Structure.Dependencies.csproj
+++ b/Structure/StructureByEnvelope/dependencies/Structure.Dependencies.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Hypar.Elements" Version="2.0.0-alpha.23" />
-    <PackageReference Include="Hypar.Functions" Version="1.5.0" />
+    <PackageReference Include="Hypar.Functions" Version="1.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Structure/StructureByEnvelope/dependencies/Structure.Dependencies.csproj
+++ b/Structure/StructureByEnvelope/dependencies/Structure.Dependencies.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="1.5.0" />
+    <PackageReference Include="Hypar.Elements" Version="2.0.0-alpha.23" />
     <PackageReference Include="Hypar.Functions" Version="1.5.0" />
   </ItemGroup>
 

--- a/Structure/StructureByEnvelope/src/Structure.cs
+++ b/Structure/StructureByEnvelope/src/Structure.cs
@@ -89,7 +89,7 @@ namespace Structure
                 var firstLevelPerimeter = firstLevel.Profile.Perimeter;
                 longestEdge = firstLevelPerimeter.Segments().OrderBy(s => s.Length()).Last();
 
-                var longestEdgeTransform = longestEdge.TransformAt(0.5);
+                var longestEdgeTransform = longestEdge.TransformAt(longestEdge.Domain.Mid());
                 var t = new Transform(longestEdge.Start, longestEdgeTransform.XAxis, longestEdge.Direction(), Vector3.ZAxis);
 
                 var toWorld = new Transform(t);
@@ -151,7 +151,7 @@ namespace Structure
                 gridLines = gridsModel.AllElementsOfType<GridLine>();
 
                 // Group by direction.
-                var gridGroups = gridLines.GroupBy(gl => gl.Curve.TransformAt(0).ZAxis).ToList();
+                var gridGroups = gridLines.GroupBy(gl => gl.Curve.TransformAt(longestEdge.Domain.Min).ZAxis).ToList();
                 primaryDirection = gridGroups[0].Key;
                 secondaryDirection = gridGroups[1].Key;
             }
@@ -160,7 +160,7 @@ namespace Structure
                 warnings.Add("Adding the Grids function to your workflow will enable you to position and orient the grid. We'll use the default configuration for now with the grid oriented along the longest edge of the structure.");
                 // Define the primary direction from the longest edge of the site.
                 primaryDirection = longestEdge.Direction();
-                secondaryDirection = longestEdge.TransformAt(0.5).XAxis;
+                secondaryDirection = longestEdge.TransformAt(longestEdge.Domain.Mid()).XAxis;
             }
 
 #if DEBUG
@@ -375,13 +375,10 @@ namespace Structure
                         girderInstance = girderDefinition.CreateInstance(t, $"{girderDefinition.Name}");
                         model.AddElement(girderInstance, false);
 
-                        if (girderDefinition is Beam beam)
+                        var modelCurve = CreateModelCurve(girderDefinition, t);
+                        if (modelCurve != null)
                         {
-                            model.AddElement(new ModelCurve(beam.Curve.Transformed(t), BuiltInMaterials.ZAxis), false);
-                        }
-                        else if (girderDefinition is Joist joist)
-                        {
-                            model.AddElement(new ModelCurve(joist.Curve.Transformed(t), BuiltInMaterials.ZAxis), false);
+                            model.AddElement(modelCurve, false);
                         }
                     }
                     else
@@ -390,13 +387,11 @@ namespace Structure
                         {
                             girderInstance = girderDefinition.CreateInstance(t, $"{girderDefinition.Name}");
                             model.AddElement(girderInstance, false);
-                            if (girderDefinition is Beam beam)
+
+                            var modelCurve = CreateModelCurve(girderDefinition, t);
+                            if (modelCurve != null)
                             {
-                                model.AddElement(new ModelCurve(beam.Curve.Transformed(t), BuiltInMaterials.ZAxis), false);
-                            }
-                            else if (girderDefinition is Joist joist)
-                            {
-                                model.AddElement(new ModelCurve(joist.Curve.Transformed(t), BuiltInMaterials.ZAxis), false);
+                                model.AddElement(modelCurve, false);
                             }
                         }
                     }
@@ -515,13 +510,10 @@ namespace Structure
                             model.AddElement(beamInstance, false);
                             var planDirection = beamDir.IsAlmostEqualTo(Vector3.ZAxis) ? Vector3.XAxis : beamDir.Project(xy).Unitized();
                             beamInstance.AdditionalProperties.Add("LabelConfiguration", new LabelConfiguration(new Color(1, 1, 1, 0), Vector3.Origin, null, null, planDirection));
-                            if (beamDefinition is Beam beam)
+                            var modelCurve = CreateModelCurve(beamDefinition, instanceTransform);
+                            if (modelCurve != null)
                             {
-                                model.AddElement(new ModelCurve(beam.Curve.Transformed(instanceTransform), BuiltInMaterials.ZAxis), false);
-                            }
-                            else if (beamDefinition is Joist joist)
-                            {
-                                model.AddElement(new ModelCurve(joist.Curve.Transformed(instanceTransform), BuiltInMaterials.ZAxis), false);
+                                model.AddElement(modelCurve, false);
                             }
                         }
                     }
@@ -539,6 +531,21 @@ namespace Structure
             output.Model = model;
             output.Warnings = warnings;
             return output;
+        }
+
+        private static ModelCurve CreateModelCurve(GeometricElement sf, Transform t)
+        {
+            BoundedCurve curve = null;
+            if (sf is Beam beam)
+            {
+                curve = beam.Curve.Transformed(t) as BoundedCurve;
+            }
+            else if (sf is Joist joist)
+            {
+                curve = joist.Curve.Transformed(t) as BoundedCurve;
+            }
+
+            return curve == null ? null : new ModelCurve(curve, BuiltInMaterials.ZAxis);
         }
 
         private static void FindOrCreateStructuralFramingDefinition(double memberLength,
@@ -580,8 +587,8 @@ namespace Structure
                 var bbox = new BBox3(bg.SelectMany(b =>
                 {
                     var def = (StructuralFraming)b.BaseDefinition;
-                    var start = b.Transform.OfPoint(def.Curve.PointAt(0));
-                    var end = b.Transform.OfPoint(def.Curve.PointAt(1));
+                    var start = b.Transform.OfPoint(def.Curve.Start);
+                    var end = b.Transform.OfPoint(def.Curve.End);
 
                     if (start.Z > maxZ)
                     {

--- a/Walls/Walls/dependencies/Walls.Dependencies.csproj
+++ b/Walls/Walls/dependencies/Walls.Dependencies.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="1.4.0" />
-    <PackageReference Include="Hypar.Functions" Version="1.3.0" />
+    <PackageReference Include="Hypar.Elements" Version="2.0.0-alpha.23" />
+    <PackageReference Include="Hypar.Functions" Version="1.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Walls/Walls/src/Walls.cs
+++ b/Walls/Walls/src/Walls.cs
@@ -20,7 +20,7 @@ namespace Walls
             if (input.Overrides?.Additions?.Walls != null)
             {
                 // Get identities for additions
-                var additionCenters = input.Overrides.Additions.Walls.Select(x => (x.Value.CenterLine.PointAt(0.5), x.Id)).Cast<(Vector3 RoughLocation, string Id)>().ToList();
+                var additionCenters = input.Overrides.Additions.Walls.Select(x => (x.Value.CenterLine.Mid(), x.Id)).Cast<(Vector3 RoughLocation, string Id)>().ToList();
 
                 // match edit overrides to addition Ids.
                 var editsByAdditionId = input.Overrides.Walls?.Select(wallEdit =>
@@ -54,7 +54,7 @@ namespace Walls
                 foreach (var newWall in input.Overrides.Additions.Walls)
                 {
                     var wallLine = newWall.Value.CenterLine;
-                    var wallCenter = wallLine.PointAt(0.5);
+                    var wallCenter = wallLine.Mid();
 
                     // get matching edit overrides
                     editsByAdditionId.TryGetValue(newWall.Id, out var matchingEdits);


### PR DESCRIPTION
Grid function was already using 2.0 but PointAt was not changed correctly to Start/Mid/End and fixed by this PR.
Other functions were updated to prevent bugs related to PointAt or TransformAt in the future.
Structure is the only function using TransformAt.

- [x] The function has been published with staging, (but not released, until this PR is approved).
- [x] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).
- [x] Strings in `hypar.json` have been translated to supported languages in the `messages` field.
- [x] Any new project added to this repository has been added to BuildingBlocks.sln.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/BuildingBlocks/150)
<!-- Reviewable:end -->
