### PR TITLE
Fix a null ref exception.

### DIFF
--- a/Structure/StructureByEnvelope/src/Structure.cs
+++ b/Structure/StructureByEnvelope/src/Structure.cs
@@ -151,7 +151,7 @@ namespace Structure
                 gridLines = gridsModel.AllElementsOfType<GridLine>();
 
                 // Group by direction.
-                var gridGroups = gridLines.GroupBy(gl => gl.Curve.TransformAt(longestEdge.Domain.Min).ZAxis).ToList();
+                var gridGroups = gridLines.GroupBy(gl => gl.Curve.TransformAt(gl.Curve.Domain.Min).ZAxis).ToList();
                 primaryDirection = gridGroups[0].Key;
                 secondaryDirection = gridGroups[1].Key;
             }


### PR DESCRIPTION
This is a small follow-on to #150 to fix a problem with the structure function which was only obvious when the containing workflow was configured in a specific way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/BuildingBlocks/151)
<!-- Reviewable:end -->
