### PR TITLE
SimpleLevelsByEnvelope: add warning message if Envelope is too small

### DIFF
--- a/Levels/SimpleLevelsByEnvelope/dependencies/LevelPerimeter.g.cs
+++ b/Levels/SimpleLevelsByEnvelope/dependencies/LevelPerimeter.g.cs
@@ -52,7 +52,7 @@ namespace Elements
         public double Elevation { get; set; }
     
         /// <summary>The perimeter of the level perimeter.</summary>
-        [JsonProperty("Perimeter", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Perimeter", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Polygon Perimeter { get; set; }
     
     

--- a/Levels/SimpleLevelsByEnvelope/src/SimpleLevelsByEnvelope.cs
+++ b/Levels/SimpleLevelsByEnvelope/src/SimpleLevelsByEnvelope.cs
@@ -56,6 +56,12 @@ namespace SimpleLevelsByEnvelope
                 currentLevel += height;
             }
 
+            if (!levels.Any())
+            {
+                output.Errors.Add($"Not enough space in 'Envelope' to create levels. Check 'Envelope' height or levels height.");
+                return output;
+            }
+
             // penthouse + roof level
             var topLevelElevation = maxElevation - input.TopLevelHeight;
             levels.Last().Height = topLevelElevation - levels.Last().Elevation;


### PR DESCRIPTION
Building Blocks contains many functions that are used in Hypar examples and in the Hypar tour. Please ensure that that following are true before granting this PR.

- [x] The function has been published with staging, (but not released, until this PR is approved).
- [x] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/BuildingBlocks/153)
<!-- Reviewable:end -->
