### PR TITLE
Fix bug with the same 45 degrees angle for X and Y

### DIFF
--- a/Grids/Grid/src/Grid.cs
+++ b/Grids/Grid/src/Grid.cs
@@ -708,9 +708,9 @@ namespace Grid
                     continue;
                 }
 
-                var angle = new Vector3(axis.End - axis.Start).AngleTo(Vector3.XAxis);
+                var angle = axis.Direction().AngleTo(Vector3.XAxis);
 
-                if (angle < 45)
+                if (angle <= 45 && axes.x == null) // in case where both x and y will have the same angle of 45 degrees
                 {
                     axes.x = axis;
                 }


### PR DESCRIPTION
- Fixed a bug that occurred if the CalculateAxes function received a polygon in which the new axes formed the same angle of inclination of 45 degrees to the X axis

Building Blocks contains many functions that are used in Hypar examples and in the Hypar tour. Please ensure that that following are true before granting this PR.

- [ ] The function has been published with staging, (but not released, until this PR is approved).
- [ ] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).
- [ ] Strings in `hypar.json` have been translated to supported languages in the `messages` field.
- [ ] Any new project added to this repository has been added to BuildingBlocks.sln.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/BuildingBlocks/159)
<!-- Reviewable:end -->
