### PR TITLE
handle nulls in ExtractPolygonsFromElements

### DIFF
--- a/Grids/Grid/src/Grid.cs
+++ b/Grids/Grid/src/Grid.cs
@@ -88,8 +88,6 @@ namespace Grid
         /// If this returns null, we'll use the 2D convex hull of the geometry of the element's representation </param>
         private static List<Polygon> ExtractPolygonsFromElements<T>(IEnumerable<T> elements, Func<T, Polygon> getDefaultPolygon) where T : GeometricElement
         {
-            List<string> warnings = new List<string>();
-
             var polygons = new List<Polygon>();
             foreach (var element in elements)
             {

--- a/Grids/Grid/src/Grid.cs
+++ b/Grids/Grid/src/Grid.cs
@@ -88,11 +88,22 @@ namespace Grid
         /// If this returns null, we'll use the 2D convex hull of the geometry of the element's representation </param>
         private static List<Polygon> ExtractPolygonsFromElements<T>(IEnumerable<T> elements, Func<T, Polygon> getDefaultPolygon) where T : GeometricElement
         {
+            List<string> warnings = new List<string>();
+
             var polygons = new List<Polygon>();
             foreach (var element in elements)
             {
-                var polygon = getDefaultPolygon(element) ?? ConvexHull.FromPoints(element.Representation.SolidOperations.SelectMany(o => o.Solid.Vertices.Select(v => new Vector3(v.Value.Point.X, v.Value.Point.Y))));
-                polygons.Add(polygon);
+                var polygon = getDefaultPolygon(element) ??
+                              ConvexHull.FromPoints(
+                                  element?.Representation?.SolidOperations?
+                                         .SelectMany(o => o?.Solid?.Vertices?
+                                                          .Select(v => new Vector3(v.Value.Point.X, v.Value.Point.Y)) ?? Enumerable.Empty<Vector3>())
+                                         .Where(v => v != null)
+                              );
+                if (polygon != null)
+                {
+                    polygons.Add(polygon);
+                }
             }
             return polygons;
         }


### PR DESCRIPTION
Building Blocks contains many functions that are used in Hypar examples and in the Hypar tour. Please ensure that that following are true before granting this PR.

- [ ] The function has been published with staging, (but not released, until this PR is approved).
- [ ] The function has been tested against the tour. If the function is not used in the tour, mark this as not applicable (NA).
- [ ] Strings in `hypar.json` have been translated to supported languages in the `messages` field.
- [ ] Any new project added to this repository has been added to BuildingBlocks.sln.

Some elements came in with null values in their SolidOperations and Profiles. This PR bolsters null handling when attempting to extract polygon info from these elements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/BuildingBlocks/161)
<!-- Reviewable:end -->
